### PR TITLE
feat: add configurable delayed orphan recovery passes

### DIFF
--- a/lib/sidekiq-assured-jobs.rb
+++ b/lib/sidekiq-assured-jobs.rb
@@ -146,6 +146,7 @@ module Sidekiq
               sleep 5 # Give the server a moment to fully start
               begin
                 reenqueue_orphans!
+                spinup_delayed_recovery_thread
               rescue => e
                 logger.error "AssuredJobs startup orphan recovery failed: #{e.message}"
                 logger.error e.backtrace.join("\n")

--- a/lib/sidekiq-assured-jobs.rb
+++ b/lib/sidekiq-assured-jobs.rb
@@ -15,7 +15,7 @@ module Sidekiq
     class Error < StandardError; end
 
     class << self
-      attr_accessor :instance_id, :namespace, :heartbeat_interval, :heartbeat_ttl, :recovery_lock_ttl, :logger, :redis_options
+      attr_accessor :instance_id, :namespace, :heartbeat_interval, :heartbeat_ttl, :recovery_lock_ttl, :logger, :redis_options, :delayed_recovery_count, :delayed_recovery_interval
 
       def configure
         yield self if block_given?
@@ -196,6 +196,8 @@ module Sidekiq
         @heartbeat_ttl ||= ENV.fetch("ASSURED_JOBS_HEARTBEAT_TTL", "45").to_i
         @recovery_lock_ttl ||= ENV.fetch("ASSURED_JOBS_RECOVERY_LOCK_TTL", "300").to_i
         @logger ||= Sidekiq.logger
+        @delayed_recovery_count ||= ENV.fetch("ASSURED_JOBS_DELAYED_RECOVERY_COUNT", "1").to_i
+        @delayed_recovery_interval ||= ENV.fetch("ASSURED_JOBS_DELAYED_RECOVERY_INTERVAL", "300").to_i
       end
 
       def setup_heartbeat
@@ -223,6 +225,20 @@ module Sidekiq
         logger.debug "AssuredJobs heartbeat sent for instance #{instance_id}"
       end
 
+      def spinup_delayed_recovery_thread
+        Thread.new do
+          @delayed_recovery_count.times do |i|
+            sleep @delayed_recovery_interval
+            begin
+              reenqueue_orphans!
+            rescue => e
+              logger.error(
+                "[AssuredJobs] delayed recovery ##{i+1} failed: #{e.message}"
+              )
+            end
+          end
+        end
+      end
       def with_recovery_lock
         lock_key = namespaced_key("recovery_lock")
         lock_acquired = redis_sync do |conn|


### PR DESCRIPTION
Introduce two new configuration options in Configuration:

delayed_recovery_interval (seconds between passes, default 300)

delayed_recovery_count (number of delayed runs, default 1)

Preserve existing immediate recovery on server startup.

In the startup hook, spawn a single helper thread that:

Sleeps for delayed_recovery_interval

Calls Recovery.reenqueue_orphans!

Repeats steps 1–2 delayed_recovery_count times

Wrap each delayed recovery in a begin…rescue block to log errors without impacting the helper thread.

No changes required in application code; all behavior is self-contained in the gem.
